### PR TITLE
Update dnsdist.init.centos6

### DIFF
--- a/pdns/dnsdistdist/contrib/dnsdist.init.centos6
+++ b/pdns/dnsdistdist/contrib/dnsdist.init.centos6
@@ -19,8 +19,8 @@ DNSDIST=/usr/bin/${PROG}
 PIDFILE=/var/run/${PROG}.pid
 DNSDIST_OPTIONS="-l 127.0.0.1:53"
 
-if [ -f /etc/default/${PROG} ]; then
-  . /etc/default/${PROG}
+if [ -f /etc/sysconfig/${PROG} ]; then
+  . /etc/sysconfig/${PROG}
 fi
 
 RETVAL=0


### PR DESCRIPTION
The init file is looking for program sepcific settings (port to listen on) in /etc/default/dnsdist.  There is no file there.  The file its looking for is in /etc/sysconfig/dnsdist.
